### PR TITLE
DOC-14677: Fix broken xrefs and includes in couchbase-lite 4.1

### DIFF
--- a/modules/android/pages/_partials/_set_page_context_for_android.adoc
+++ b/modules/android/pages/_partials/_set_page_context_for_android.adoc
@@ -8,8 +8,6 @@ ifdef::is_diag[_set_page_context_for_android]
 :param_is_root!:
 :version-maintenance-android: {major}.{minor}.{maintenance-android}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 // :module: {param-module}
 // :packageNm: couchbase-lite-{module}

--- a/modules/android/pages/compatibility.adoc
+++ b/modules/android/pages/compatibility.adoc
@@ -246,7 +246,7 @@ h| .NET
 * xref:android:releasenotes.adoc[Release Notes]
 * xref:android:compatibility.adoc[Compatibility]
 * xref:android:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 .
 

--- a/modules/android/pages/supported-os.adoc
+++ b/modules/android/pages/supported-os.adoc
@@ -8,7 +8,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:android:releasenotes.adoc[Release Notes] | xref:android:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:android:releasenotes.adoc[Release Notes] | xref:android:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]

--- a/modules/c/pages/_partials/_set_page_context_for_c.adoc
+++ b/modules/c/pages/_partials/_set_page_context_for_c.adoc
@@ -9,8 +9,6 @@ ifdef::is_diag[_set_page_context_for_C]
 :version-maintenance-c: {major}.{minor}.{maintenance-c}
 :version-maintenance: {major}.{minor}.{maintenance-c}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/c/pages/compatibility.adoc
+++ b/modules/c/pages/compatibility.adoc
@@ -240,7 +240,7 @@ h|  .NET
 * xref:c:releasenotes.adoc[Release Notes]
 * xref:c:compatibility.adoc[Compatibility]
 * xref:c:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 
 .

--- a/modules/c/pages/conflict.adoc
+++ b/modules/c/pages/conflict.adoc
@@ -171,7 +171,7 @@ Local Wins::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=local-win-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=local-win-conflict-resolver,indent=0]
 ----
 --
 
@@ -180,7 +180,7 @@ Remote Wins::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=remote-win-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=remote-win-conflict-resolver,indent=0]
 ----
 --
 
@@ -189,7 +189,7 @@ Merge::
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tag=merge-conflict-resolver,indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tag=merge-conflict-resolver,indent=0]
 ----
 --
 

--- a/modules/c/pages/query-live.adoc
+++ b/modules/c/pages/query-live.adoc
@@ -70,7 +70,7 @@ Save the token to detach the listener and stop the query later -- see xref:c:que
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="live-query", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="live-query", indent=0]
 ----
 <.> Build the query statements
 <.> Activate the _live_ query by attaching a listener.
@@ -114,7 +114,7 @@ Doing so stops the live query.
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="stop-live-query", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="stop-live-query", indent=0]
 ----
 <.> Here we use the change listener token from xref:c:query-live.adoc#ex-qry-start[] to remove the listener.
 Doing so stops the live query.

--- a/modules/c/pages/query-n1ql-mobile.adoc
+++ b/modules/c/pages/query-n1ql-mobile.adoc
@@ -58,7 +58,7 @@ include::c:example$code_snippets/main.cpp[tags="query-syntax-n1ql", indent=0]
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="query-syntax-n1ql", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="query-syntax-n1ql", indent=0]
 ----
 --
 =====
@@ -2329,7 +2329,7 @@ include::c:example$code_snippets/main.cpp[tags="query-syntax-n1ql-params", inden
 
 C++::
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="query-syntax-n1ql-params", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="query-syntax-n1ql-params", indent=0]
 ----
 --
 =====

--- a/modules/c/pages/query-resultsets.adoc
+++ b/modules/c/pages/query-resultsets.adoc
@@ -82,7 +82,7 @@ You can add this dictionary to an array of returned matches, for processing else
 --
 [source, cpp]
 ----
-include::c:example$code_snippets/cbl_cpp.cpp[tags="query-access-all", indent=0]
+include::c:example$code_snippets_cpp/cbl_cpp.cpp[tags="query-access-all", indent=0]
 ----
 <.> Here we get the dictionary of document properties using the database name as the key.
 You can add this dictionary to an array of returned matches, for processing elsewhere in the app.

--- a/modules/c/pages/supported-os.adoc
+++ b/modules/c/pages/supported-os.adoc
@@ -13,7 +13,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:c:releasenotes.adoc[Release Notes] | xref:c:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:c:releasenotes.adoc[Release Notes] | xref:c:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]

--- a/modules/csharp/pages/_partials/_set_page_context_for_csharp.adoc
+++ b/modules/csharp/pages/_partials/_set_page_context_for_csharp.adoc
@@ -9,8 +9,6 @@ ifdef::is_diag[_set_page_context_for C#/.NET]
 :version-maintenance-net: {major}.{minor}.{maintenance-net}
 :version-maintenance: {major}.{minor}.{maintenance-net}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/csharp/pages/compatibility.adoc
+++ b/modules/csharp/pages/compatibility.adoc
@@ -237,7 +237,7 @@ h|  .NET
 * xref:csharp:releasenotes.adoc[Release Notes]
 * xref:csharp:compatibility.adoc[Compatibility]
 * xref:csharp:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 
 .

--- a/modules/csharp/pages/supported-os.adoc
+++ b/modules/csharp/pages/supported-os.adoc
@@ -10,7 +10,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:csharp:releasenotes.adoc[Release Notes] | xref:csharp:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:csharp:releasenotes.adoc[Release Notes] | xref:csharp:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]

--- a/modules/hybrid/pages/_partials/_set_page_context_for_hybrid.adoc
+++ b/modules/hybrid/pages/_partials/_set_page_context_for_hybrid.adoc
@@ -7,8 +7,6 @@ ifdef::is_diag[_set_page_context_for_hybrid]
 :source-language: {param-name}
 :param_is_root!:
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/hybrid/pages/_partials/_set_page_context_for_javascript.adoc
+++ b/modules/hybrid/pages/_partials/_set_page_context_for_javascript.adoc
@@ -7,8 +7,6 @@ ifdef::is_diag[_set_page_context_for_hybrid]
 :source-language: {param-name}
 :param_is_root!:
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/java/pages/_partials/_set_page_context_for_java.adoc
+++ b/modules/java/pages/_partials/_set_page_context_for_java.adoc
@@ -8,8 +8,6 @@ ifdef::is_diag[_set_page_context_for_java]
 :param_is_root!:
 :version-maintenance-java: {major}.{minor}.{maintenance-java}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{param-module}

--- a/modules/java/pages/compatibility.adoc
+++ b/modules/java/pages/compatibility.adoc
@@ -237,7 +237,7 @@ h|  .NET
 * xref:java:releasenotes.adoc[Release Notes]
 * xref:java:compatibility.adoc[Compatibility]
 * xref:java:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 
 .

--- a/modules/java/pages/supported-os.adoc
+++ b/modules/java/pages/supported-os.adoc
@@ -10,7 +10,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:java:releasenotes.adoc[Release Notes] | xref:java:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:java:releasenotes.adoc[Release Notes] | xref:java:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]

--- a/modules/objc/pages/_partials/_set_page_context_for_objc.adoc
+++ b/modules/objc/pages/_partials/_set_page_context_for_objc.adoc
@@ -8,8 +8,6 @@ ifdef::is_diag[_set_page_context_for_objc]
 :param_is_root!:
 :version-maintenance-ios: {major}.{minor}.{maintenance-ios}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/objc/pages/compatibility.adoc
+++ b/modules/objc/pages/compatibility.adoc
@@ -231,7 +231,7 @@ h| .NET
 * xref:objc:releasenotes.adoc[Release Notes]
 * xref:objc:compatibility.adoc[Compatibility]
 * xref:objc:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 .
 

--- a/modules/objc/pages/supported-os.adoc
+++ b/modules/objc/pages/supported-os.adoc
@@ -8,7 +8,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:objc:releasenotes.adoc[Release Notes] | xref:objc:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:objc:releasenotes.adoc[Release Notes] | xref:objc:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]

--- a/modules/swift/pages/_partials/_set_page_context_for_swift.adoc
+++ b/modules/swift/pages/_partials/_set_page_context_for_swift.adoc
@@ -8,8 +8,6 @@ ifdef::is_diag[_set_page_context_for_swift]
 :param_is_root!:
 :version-maintenance-swift: {major}.{minor}.{maintenance-swift}
 
-include::ROOT:partial$_set_page_context.adoc[]
-
 // BEGIN::module page attributes
 :module: {param-module}
 :packageNm: couchbase-lite-{module}

--- a/modules/swift/pages/compatibility.adoc
+++ b/modules/swift/pages/compatibility.adoc
@@ -240,7 +240,7 @@ h| .NET
 * xref:swift:releasenotes.adoc[Release Notes]
 * xref:swift:compatibility.adoc[Compatibility]
 * xref:swift:supported-os.adoc[Supported Platforms]
-* xref:cbl-whatsnew.adoc[What's New]
+* xref:ROOT:cbl-whatsnew.adoc[What's New]
 
 .
 

--- a/modules/swift/pages/supported-os.adoc
+++ b/modules/swift/pages/supported-os.adoc
@@ -8,7 +8,7 @@
 [abstract]
 --
 Description -- _{description}_ +
-Related Content -- xref:cbl-whatsnew.adoc[What's New]  |  xref:swift:releasenotes.adoc[Release Notes] | xref:swift:compatibility.adoc[Compatibility]
+Related Content -- xref:ROOT:cbl-whatsnew.adoc[What's New]  |  xref:swift:releasenotes.adoc[Release Notes] | xref:swift:compatibility.adoc[Compatibility]
 --
 
 [#officially-supported-versions]


### PR DESCRIPTION
  This PR fixes 20 of 169 build errors on couchbase-lite  4.1 — 
all mechanical (missing module prefixes, a wrong directory name, and a dead include left over from the DOC-13273 partial-flattening work). 

## Remaining 149 errors 🙈 

The remaining 149 fall into a few concentrated buckets, two of which are large content/architecture decisions rather than link fixes:

  1. "Peer-to-Peer Sync" landing page was deliberately un-published (~45 errors)
  landing-p2psync.adoc is linked from dozens of pages across every platform. It wasn't deleted — it was
  renamed with a leading dot (.landing-p2psync.adoc), Antora's convention for hiding a page while keeping its
  content in the repo. Only the C module still has this hidden file with real content; every other platform's
  copy is gone entirely. Needs a decision: republish, redirect these links elsewhere
  (landing-replications.adoc exists on some platforms), or confirm this was intentional and strip the links.

  2. JavaScript rows in the six compatibility.adoc tables assume JS is a module inside couchbase-lite (~42
  errors) It isn't — modules/javascript/ was migrated out into its own top-level repo/component, couchbase-lite-js
  (currently versioned 1.0, not tracking the main  product's 2.8–4.1 numbering). There's no equivalent
  per-version "supported OS" page over there for the historical-version comparison row to link to. Real fix
  requires deciding what (if anything) that row should show now.

  3. csharp:gs-prereqs.adoc (14 errors) — page doesn't exist; gs-install.adoc looks like the likely successor
  but has no "Prerequisites" section to anchor into.

  4. c:querybuilder.adoc (6 errors) — every other platform has QueryBuilder docs; C does not. These look
  like "Related Content" footers copy-pasted from another platform's template without adjusting for C, where the
  API doesn't apply.

  5. swift/java/csharp/android:supported-os.adoc pinned to old versions 2.8–4.0 (24 errors) — pages genuinely
  exist at those historical branches, so this looks like a playbook-scope issue (same pattern as the SDK version
  pins we found in docs-server), not a content bug.

  6. A handful of one-offs needing individual triage: objc:new-logging-logs.adoc (likely renamed to
  new-logging-api.adoc), objc:replication.adoc linking to swift:index.adoc (wrong platform),
  csharp:replication:p2psync-websocket.adoc (module/family mismatch), kotlin:supported-os.adoc,
  android:ppsync-multipeer-transports.adoc.