### PR TITLE
updated the bluetooth requirements for ios

### DIFF
--- a/modules/objc/pages/p2psync-multipeer.adoc
+++ b/modules/objc/pages/p2psync-multipeer.adoc
@@ -109,14 +109,19 @@ To use Wi-Fi transport, declare the Bonjour service type and a local network usa
 
 ==== Bluetooth Transport
 
-To use Bluetooth transport, declare a Bluetooth usage description.
+To use Bluetooth transport, complete the following:
 
+. Declare the Bluetooth usage description in `Info.plist`.
++
 .NSBluetoothAlwaysUsageDescription
 [source,xml]
 ----
 <key>NSBluetoothAlwaysUsageDescription</key>
 <string>Used for discovering and connecting to peers for peer-to-peer sync.</string>
 ----
+
+. Link the `CoreBluetooth.framework` framework in your application target.
+In Xcode, add it under *General > Frameworks, Libraries, and Embedded Content*, or add it in the *Link Binary With Libraries* build phase.
 
 
 == Configuration

--- a/modules/swift/pages/p2psync-multipeer.adoc
+++ b/modules/swift/pages/p2psync-multipeer.adoc
@@ -113,14 +113,19 @@ To use Wi-Fi transport, declare the Bonjour service type and a local network usa
 
 ==== Bluetooth Transport
 
-To use Bluetooth transport, declare a Bluetooth usage description.
+To use Bluetooth transport, complete the following:
 
+. Declare the Bluetooth usage description in `Info.plist`.
++
 .NSBluetoothAlwaysUsageDescription
 [source,xml]
 ----
 <key>NSBluetoothAlwaysUsageDescription</key>
 <string>Used for discovering and connecting to peers for peer-to-peer sync.</string>
 ----
+
+. Link the `CoreBluetooth.framework` framework in your application target.
+In Xcode, add it under *General > Frameworks, Libraries, and Embedded Content*, or add it in the *Link Binary With Libraries* build phase.
 
 
 == Configuration


### PR DESCRIPTION
PR to update the iOS bluetooth requirement for 4.1 

Preview URL:
https://preview.docs-test.couchbase.com/docs-couchbase-lite-update-ios-4-1-requirements

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.